### PR TITLE
Add white background color to error container

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var createCssStringLiteral = require('./lib/createCssStringLiteral');
 
 function createCssError(str, doubleEscape) {
-  var tpl = 'body * {\n  display: none !important;\n}\n\nbody:before {\n  line-height: 1.5;\n  display: block;\n  z-index: 99999999;\n  white-space: pre;\n  font-family: "Courier New", monospace;\n  font-size: 20px;\n  color: black;\n  margin: 10px;\n  padding: 10px;\n  border: 4px dashed red;\n  margin-bottom: 10px;\n  content: __ERRORMESSAGE__;\n}\n';
+  var tpl = 'body * {\n  display: none !important;\n}\n\nbody:before {\n  line-height: 1.5;\n  display: block;\n  z-index: 99999999;\n  white-space: pre;\n  font-family: "Courier New", monospace;\n  font-size: 20px;\n  color: black;\n  background-color: white;\n  margin: 10px;\n  padding: 10px;\n  border: 4px dashed red;\n  margin-bottom: 10px;\n  content: __ERRORMESSAGE__;\n}\n';
 
   return tpl.replace('__ERRORMESSAGE__', createCssStringLiteral(str, doubleEscape));
 }


### PR DESCRIPTION
If websites have a dark background then the error text becomes difficult to read, this fixes that.
